### PR TITLE
Use pointer cursors on call-no-answer button

### DIFF
--- a/omod/src/main/webapp/pages/patientList.gsp
+++ b/omod/src/main/webapp/pages/patientList.gsp
@@ -101,7 +101,7 @@ var x = OPENMRS_CONTEXT_PATH + "/patientlist/patientList.page";
 <!-- <td>${ ui.format(it.id)}</td>  -->
 
     <% if (role.equals("dr")) { %>
-        <td onclick="addToCallAttempts($it.id)"> <i  class="icon-">&#xf0fe;</i></td>
+        <td style="cursor:pointer" onclick="addToCallAttempts($it.id)"> <i  class="icon-">&#xf0fe;</i></td>
     <% } %>
 
 <td>${ ui.format(it.patientName)}</td>


### PR DESCRIPTION
On `/openmrs/patientlist/patientList.page` the cursor style should be pointer to indicate that the button is clickable